### PR TITLE
Add filmmakers_url to agency docs

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -626,6 +626,7 @@ curl "https://www.filmmakers.eu/api/v1/talent_agencies/123" \
     "phone": "49613163691950",
     "zipcode": "55122"
   },
+  "filmmakers_url":"https://www.filmmakers.eu/agents/example-agency",
   "employees": [
     {
       "id": 1,

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -611,6 +611,7 @@ curl "https://www.filmmakers.eu/api/v1/talent_agencies/123" \
   "name": "Example agency",
   "short_name": "Agency",
   "homepage_url": "https://www.example.com",
+  "filmmakers_url": "https://www.filmmakers.eu/agents/example-agency",
   "imdb_link": "https://pro.imdb.com/company/co0000001",
   "imdb_id": "co0000001",
   "showreel_url": "https://www.example.com/showreel",
@@ -626,7 +627,6 @@ curl "https://www.filmmakers.eu/api/v1/talent_agencies/123" \
     "phone": "49613163691950",
     "zipcode": "55122"
   },
-  "filmmakers_url":"https://www.filmmakers.eu/agents/example-agency",
   "employees": [
     {
       "id": 1,


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->
Companion PR: https://github.com/denkungsart/filmmakers/pull/11293

This PR introduces the following changes:

* Add `filmmakers_url` to talent agency endpoint documentation