### PR TITLE
Adjust example for episode_name

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -505,10 +505,11 @@ curl "https://www.filmmakers.eu/api/v1/actor_profiles/123" \
       {
         "info": null,
         "name": "Mord mit Aussicht",
+        "episode_name": "Sophie kommet doch all",
         "year_from": 2015,
         "year_to": 2016,
         "role": "Robert",
-        "role_type": "misc",
+        "role_type": "episode_featured_part",
         "distributor": null,
         "director": null,
         "producer": null,

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -135,6 +135,7 @@ expected_signature == signature["v1"]
 
 
 # Changelog
+- (2024-03-19) **ActorProfile#show**: Add new field `episode_name` to Vita
 - (2023-08-17) **ActorProfile#index**: Added possibility to filter by `updated_at`
 - (2023-05-31) **ActorProfile#index**:
   - Also emit `picture_copyright` if `include_picture` is specified


### PR DESCRIPTION
Based on changes in https://github.com/denkungsart/filmmakers/pull/11025

- include `episode_name` and specific role type in vita example
- add changelog entry