### PR TITLE
Add type_genre to episode_name vita example

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -509,6 +509,7 @@ curl "https://www.filmmakers.eu/api/v1/actor_profiles/123" \
         "episode_name": "Sophie kommet doch all",
         "year_from": 2015,
         "year_to": 2016,
+        "type_genre": "series",
         "role": "Robert",
         "role_type": "episode_featured_part",
         "distributor": null,


### PR DESCRIPTION
References https://github.com/denkungsart/filmmakers/pull/11025

- add `type_genre` to example since this is now the dependency for the `episode_name` field