### PR TITLE
Adds documentation for new gender attributes

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -155,6 +155,7 @@ Filmmakers uses conventional HTTP response codes to indicate the success or fail
 Certain `4xx` errors, notably the `410` Gone status, indicate that a requested resource (such as an actor_profile or a talent_agency) has been merged with another and is no longer available at the original URL. The response will include the ID of the new resource, and clients should use this ID to access the merged resource.
 
 # Changelog
+- (2024-07-01) **ActorProfile#index**: Add new field `gender_description`
 - (2024-05-20) **ActorProfile#index**: Add new field `gender_searchability`
 - (2024-05-16) **ActorProfile#index**: Add new field `gender_new`, which replaces 'diverse' value with a larger range of gender values.
 - (2024-04-26) **ActorProfile#show**: Add new field `in_development` to Vita<br>
@@ -211,7 +212,7 @@ page | 1 | Page to display - see "Pagination" section
 per_page | 250 | Items per page - see "Pagination" section
 include_picture | false | If set to true, the result will include the profile picture thumbnail in a field named `main_picture_url_tile`.
 picture_version | null | Can be set to `original`, `large` or `thumb` to change the included picture version. The picture will be included in a field named `picture_url`. _(Only applies if `include_picture` is true)_
-fields | name,gender | Can be used to modify the fields included in the response. Possible values are: `age`, `gender`, `gender_new`, `gender_searchability`, `first_name`, `last_name`, `name`, `main_profession`, `professions`, `languages`, `representative`, `updated_at`.
+fields | name,gender | Can be used to modify the fields included in the response. Possible values are: `age`, `gender`, `gender_new`, `gender_description`, `gender_searchability`, `first_name`, `last_name`, `name`, `main_profession`, `professions`, `languages`, `representative`, `updated_at`.
 order | id | Changes the order of returned results. Possible values are: `id`, `name`, `last_name`
 gender | null | Allows filtering by gender. Possible values are: `m`, `f`, `i`.
 gender_new | null | Allows filtering by gender_new values. Possible values are: `male`, `female`, `transgender_female`, `transgender_male`, `non_binary`, `custom`.
@@ -226,6 +227,7 @@ id | number | Unique ID of the actor profile
 age | number |
 gender | string | `f` for female, `m` for male, `i` for diverse
 gender_new | string | `female` for female, `male` for male, `transgender_male` for transgender male, `transgender_female` for transgender female, `non_binary` for non binary, `custom` for custom set gender
+gender_description | string |
 gender_searchability | array of strings | list of genders actor profile can be found under, e.g. `["female", "non_binary"]` _this always at least includes the gender of the actor profile if visible_
 name | string | Full name (ie. first & last name) _name can be retrieved separately by using the fields parameter_
 first_name | string |
@@ -303,6 +305,7 @@ curl "https://www.filmmakers.eu/api/v1/actor_profiles/123" \
   "city": "Mainz",
   "gender": "m",
   "gender_new": "male",
+  "gender_description": "genderfluid",
   "gender_searchability": [
     "male"
   ],

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -214,8 +214,7 @@ include_picture | false | If set to true, the result will include the profile pi
 picture_version | null | Can be set to `original`, `large` or `thumb` to change the included picture version. The picture will be included in a field named `picture_url`. _(Only applies if `include_picture` is true)_
 fields | name,gender | Can be used to modify the fields included in the response. Possible values are: `age`, `gender`, `gender_new`, `gender_description`, `gender_searchability`, `first_name`, `last_name`, `name`, `main_profession`, `professions`, `languages`, `representative`, `updated_at`.
 order | id | Changes the order of returned results. Possible values are: `id`, `name`, `last_name`
-gender | null | Allows filtering by gender. Possible values are: `m`, `f`, `i`.
-gender_new | null | Allows filtering by gender_new values. Possible values are: `male`, `female`, `transgender_female`, `transgender_male`, `non_binary`, `custom`.
+gender | null | Allows filtering by gender values. Possible values are: `male`, `female`, `transgender_female`, `transgender_male`, `non_binary`, `custom`.
 updated_at[gte] | null | Allows filtering for profiles updated since the passed timestamp. Passed as an integer Unix timestamp.
 q | null | Allows filtering by name. Uses trigram, so allows fuzzy & partial matches
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -213,7 +213,8 @@ include_picture | false | If set to true, the result will include the profile pi
 picture_version | null | Can be set to `original`, `large` or `thumb` to change the included picture version. The picture will be included in a field named `picture_url`. _(Only applies if `include_picture` is true)_
 fields | name,gender | Can be used to modify the fields included in the response. Possible values are: `age`, `gender`, `gender_new`, `gender_searchability`, `first_name`, `last_name`, `name`, `main_profession`, `professions`, `languages`, `representative`, `updated_at`.
 order | id | Changes the order of returned results. Possible values are: `id`, `name`, `last_name`
-gender | null | Allows filtering by gender. Possible values are: `m`, `f`, `i`, `male`, `female`, `transgender_female`, `transgender_male`, `non_binary`, `custom`
+gender | null | Allows filtering by gender. Possible values are: `m`, `f`, `i`.
+gender_new | null | Allows filtering by gender_new values. Possible values are: `male`, `female`, `transgender_female`, `transgender_male`, `non_binary`, `custom`.
 updated_at[gte] | null | Allows filtering for profiles updated since the passed timestamp. Passed as an integer Unix timestamp.
 q | null | Allows filtering by name. Uses trigram, so allows fuzzy & partial matches
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -155,8 +155,8 @@ Filmmakers uses conventional HTTP response codes to indicate the success or fail
 Certain `4xx` errors, notably the `410` Gone status, indicate that a requested resource (such as an actor_profile or a talent_agency) has been merged with another and is no longer available at the original URL. The response will include the ID of the new resource, and clients should use this ID to access the merged resource.
 
 # Changelog
-- (2024-07-01) **ActorProfile#index**: Add new field `gender_description`
-- (2024-05-20) **ActorProfile#index**: Add new field `gender_searchability`
+- (2024-07-01) **ActorProfile#show**: Add new field `gender_description`
+- (2024-05-20) **ActorProfile#show**: Add new field `gender_searchability`
 - (2024-05-16) **ActorProfile#index**: Add new field `gender_new`, which replaces 'diverse' value with a larger range of gender values.
 - (2024-04-26) **ActorProfile#show**: Add new field `in_development` to Vita<br>
 - (2024-04-12) **ActorProfile#show**: Add new fields `main_profession` and `specializations`<br>
@@ -212,7 +212,7 @@ page | 1 | Page to display - see "Pagination" section
 per_page | 250 | Items per page - see "Pagination" section
 include_picture | false | If set to true, the result will include the profile picture thumbnail in a field named `main_picture_url_tile`.
 picture_version | null | Can be set to `original`, `large` or `thumb` to change the included picture version. The picture will be included in a field named `picture_url`. _(Only applies if `include_picture` is true)_
-fields | name,gender | Can be used to modify the fields included in the response. Possible values are: `age`, `gender`, `gender_new`, `gender_description`, `gender_searchability`, `first_name`, `last_name`, `name`, `main_profession`, `professions`, `languages`, `representative`, `updated_at`.
+fields | name,gender | Can be used to modify the fields included in the response. Possible values are: `age`, `gender`, `gender_new`, `first_name`, `last_name`, `name`, `main_profession`, `professions`, `languages`, `representative`, `updated_at`.
 order | id | Changes the order of returned results. Possible values are: `id`, `name`, `last_name`
 gender | null | Allows filtering by gender values. Possible values are: `male`, `female`, `transgender_female`, `transgender_male`, `non_binary`, `custom`.
 updated_at[gte] | null | Allows filtering for profiles updated since the passed timestamp. Passed as an integer Unix timestamp.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -155,7 +155,8 @@ Filmmakers uses conventional HTTP response codes to indicate the success or fail
 Certain `4xx` errors, notably the `410` Gone status, indicate that a requested resource (such as an actor_profile or a talent_agency) has been merged with another and is no longer available at the original URL. The response will include the ID of the new resource, and clients should use this ID to access the merged resource.
 
 # Changelog
-- (2024-05-16) **ActorProfile#index**: Add new field `long_gender`
+- (2024-05-20) **ActorProfile#index**: Add new field `gender_searchability`
+- (2024-05-16) **ActorProfile#index**: Add new field `gender_new`, which replaces 'diverse' value with a larger range of gender values.
 - (2024-04-26) **ActorProfile#show**: Add new field `in_development` to Vita<br>
 - (2024-04-12) **ActorProfile#show**: Add new fields `main_profession` and `specializations`<br>
 **ActorProfile#index**: Add new field `main_profession`
@@ -210,9 +211,9 @@ page | 1 | Page to display - see "Pagination" section
 per_page | 250 | Items per page - see "Pagination" section
 include_picture | false | If set to true, the result will include the profile picture thumbnail in a field named `main_picture_url_tile`.
 picture_version | null | Can be set to `original`, `large` or `thumb` to change the included picture version. The picture will be included in a field named `picture_url`. _(Only applies if `include_picture` is true)_
-fields | name,gender | Can be used to modify the fields included in the response. Possible values are: `age`, `gender`, `long_gender`, `first_name`, `last_name`, `name`, `main_profession`, `professions`, `languages`, `representative`, `updated_at`.
+fields | name,gender | Can be used to modify the fields included in the response. Possible values are: `age`, `gender`, `gender_new`, `gender_searchability`, `first_name`, `last_name`, `name`, `main_profession`, `professions`, `languages`, `representative`, `updated_at`.
 order | id | Changes the order of returned results. Possible values are: `id`, `name`, `last_name`
-gender | null | Allows filtering by gender. Possible values are: `m`, `f`, `i`.
+gender | null | Allows filtering by gender. Possible values are: `m`, `f`, `i`, `male`, `female`, `transgender_female`, `transgender_male`, `non_binary`, `custom`
 updated_at[gte] | null | Allows filtering for profiles updated since the passed timestamp. Passed as an integer Unix timestamp.
 q | null | Allows filtering by name. Uses trigram, so allows fuzzy & partial matches
 
@@ -223,7 +224,8 @@ Field | Type | Description
 id | number | Unique ID of the actor profile
 age | number |
 gender | string | `f` for female, `m` for male, `i` for diverse
-long_gender | string | `female` for female, `male` for male, `intersex` for diverse, `transgender_male` for transgender male, `transgender_female` for transgender female, `non_binary` for non binary, `custom` for custom set gender
+gender_new | string | `female` for female, `male` for male, `transgender_male` for transgender male, `transgender_female` for transgender female, `non_binary` for non binary, `custom` for custom set gender
+gender_searchability | array of strings | list of genders actor profile can be found under, e.g. `["female", "non_binary"]` _this always at least includes the gender of the actor profile if visible_
 name | string | Full name (ie. first & last name) _name can be retrieved separately by using the fields parameter_
 first_name | string |
 last_name | string |
@@ -299,7 +301,10 @@ curl "https://www.filmmakers.eu/api/v1/actor_profiles/123" \
   "place_of_birth": "Darmstadt",
   "city": "Mainz",
   "gender": "m",
-  "long_gender": "male",
+  "gender_new": "male",
+  "gender_searchability": [
+    "male"
+  ],
   "eye_color": "braun",
   "hair_color": "braun",
   "hair_length": "mittel",

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -155,6 +155,7 @@ Filmmakers uses conventional HTTP response codes to indicate the success or fail
 Certain `4xx` errors, notably the `410` Gone status, indicate that a requested resource (such as an actor_profile or a talent_agency) has been merged with another and is no longer available at the original URL. The response will include the ID of the new resource, and clients should use this ID to access the merged resource.
 
 # Changelog
+- (2024-05-16) **ActorProfile#index**: Add new field `long_gender`
 - (2024-04-26) **ActorProfile#show**: Add new field `in_development` to Vita<br>
 - (2024-04-12) **ActorProfile#show**: Add new fields `main_profession` and `specializations`<br>
 **ActorProfile#index**: Add new field `main_profession`
@@ -209,7 +210,7 @@ page | 1 | Page to display - see "Pagination" section
 per_page | 250 | Items per page - see "Pagination" section
 include_picture | false | If set to true, the result will include the profile picture thumbnail in a field named `main_picture_url_tile`.
 picture_version | null | Can be set to `original`, `large` or `thumb` to change the included picture version. The picture will be included in a field named `picture_url`. _(Only applies if `include_picture` is true)_
-fields | name,gender | Can be used to modify the fields included in the response. Possible values are: `age`, `gender`, `first_name`, `last_name`, `name`, `main_profession`, `professions`, `languages`, `representative`, `updated_at`.
+fields | name,gender | Can be used to modify the fields included in the response. Possible values are: `age`, `gender`, `long_gender`, `first_name`, `last_name`, `name`, `main_profession`, `professions`, `languages`, `representative`, `updated_at`.
 order | id | Changes the order of returned results. Possible values are: `id`, `name`, `last_name`
 gender | null | Allows filtering by gender. Possible values are: `m`, `f`, `i`.
 updated_at[gte] | null | Allows filtering for profiles updated since the passed timestamp. Passed as an integer Unix timestamp.
@@ -222,6 +223,7 @@ Field | Type | Description
 id | number | Unique ID of the actor profile
 age | number |
 gender | string | `f` for female, `m` for male, `i` for diverse
+long_gender | string | `female` for female, `male` for male, `intersex` for diverse, `transgender_male` for transgender male, `transgender_female` for transgender female, `non_binary` for non binary, `custom` for custom set gender
 name | string | Full name (ie. first & last name) _name can be retrieved separately by using the fields parameter_
 first_name | string |
 last_name | string |
@@ -297,6 +299,7 @@ curl "https://www.filmmakers.eu/api/v1/actor_profiles/123" \
   "place_of_birth": "Darmstadt",
   "city": "Mainz",
   "gender": "m",
+  "long_gender": "male",
   "eye_color": "braun",
   "hair_color": "braun",
   "hair_length": "mittel",


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

Ref https://github.com/denkungsart/filmmakers/issues/5376
* add explanations about new field "new_gender"
* add explanations about new field "gender_searchablity"
* add explanations about query parameter "gender_new"
* include examples in JSON