### PR TITLE
Explain tags attribute for blog posts index view

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1061,7 +1061,9 @@ tags[id] | null | Filter items by tags - allows passing multiple tag ids using a
 Field | Type | Description
 --------- | ------- | -----------
 id | number | Unique ID of the blog post
+blog_id | number | Unique ID of the blog the post belongs to
 title | string | Title of the blog post
+tags | array of objects | Includes ID and name of the associated tags
 
 ## Get a specific blog post
 


### PR DESCRIPTION
References https://github.com/denkungsart/filmmakers/issues/12980

- add `tags` attribute to JSON example and responsive fields table
- add `blog_id` also (unrelated to the issue, but it was missing)